### PR TITLE
[WIP] ResponsiveTable component

### DIFF
--- a/src/component/Primitive/ResponsiveTable/ResponsiveTable.module.scss
+++ b/src/component/Primitive/ResponsiveTable/ResponsiveTable.module.scss
@@ -1,0 +1,24 @@
+@import '../../../scss/function/spacing';
+
+// .ResponsiveTable {}
+
+.ResponsiveTableTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+// to compose common styles in <th> and <td> components
+.ResponsiveTableCommonCellStyles {
+  text-align: left;
+  padding: spacing(1);
+  font-variant-numeric: tabular-nums;
+  vertical-align: baseline;
+
+  &:first-child {
+    padding-left: spacing(6);
+  }
+
+  &:last-child {
+    padding-right: spacing(6);
+  }
+}

--- a/src/component/Primitive/ResponsiveTable/ResponsiveTable.stories.jsx
+++ b/src/component/Primitive/ResponsiveTable/ResponsiveTable.stories.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import ResponsiveTable from '.'
+
+import * as rugbyFixture from './fixture/rugby'
+import * as olympicsFixture from './fixture/olympics'
+import * as footballFixture from './fixture/football'
+
+const stories = storiesOf('Specialised/ResponsiveTable', module)
+
+stories.add(
+  'Info',
+  () => <ResponsiveTable cols={rugbyFixture.cols} rows={rugbyFixture.rows} />,
+  {
+    info: {
+      inline: true,
+      text: `
+      Starter component which can be duplicated and used as a starting point
+      for others.
+
+      Use this first story to add documentation and show off the most
+      interesting/useful component iteration. Use subsequent stories to detail
+      all component permutations.
+    `
+    }
+  }
+)
+
+stories.add('Example: Rugby', () => (
+  <ResponsiveTable cols={rugbyFixture.cols} rows={rugbyFixture.rows} />
+))
+
+stories.add('Example: Olympics', () => (
+  <ResponsiveTable cols={olympicsFixture.cols} rows={olympicsFixture.rows} />
+))
+
+stories.add('Example: Football', () => (
+  <ResponsiveTable cols={footballFixture.cols} rows={footballFixture.rows} />
+))

--- a/src/component/Primitive/ResponsiveTable/ResponsiveTable.test.jsx
+++ b/src/component/Primitive/ResponsiveTable/ResponsiveTable.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import validatePropTypes from 'validate-prop-types'
+import { shallow } from 'enzyme'
+import ResponsiveTable from '.'
+
+const requiredProps = () => ({
+  cols: [{ title: 'Column 1' }, { title: 'Column 2' }],
+  rows: [
+    { data: ['Row 1, Col 1', 'Row 1, Col 2'] },
+    { data: ['Row 2, Col 1', 'Row 2, Col 2'] }
+  ]
+})
+
+describe('Component: ResponsiveTable', function() {
+  test('should return errors if required props missing', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(ResponsiveTable.propTypes, {})
+    const expected = {
+      cols:
+        'The prop `cols` is marked as required in `Component`, but its value is `undefined`.',
+      rows:
+        'The prop `rows` is marked as required in `Component`, but its value is `undefined`.'
+    }
+    expect(actual).toEqual(expected)
+  })
+
+  test('shouldn’t error if valid default props passed', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(ResponsiveTable.propTypes, requiredProps())
+    const expected = undefined
+    expect(actual).toEqual(expected)
+  })
+
+  test('should output the expected markup with default props', function() {
+    const wrapper = shallow(<ResponsiveTable {...requiredProps()} />)
+    expect(wrapper.prop('className')).toEqual('ResponsiveTable')
+    expect(wrapper.find('table').length).toEqual(1)
+    expect(wrapper.find('ResponsiveTableHeaderCell').length).toEqual(2)
+    expect(wrapper.find('ResponsiveTableRow').length).toEqual(2)
+    expect(wrapper.find('ResponsiveTableDataCell').length).toEqual(4)
+    expect(wrapper.find('style').length).toEqual(0)
+  })
+
+  test('should output `<style>` if cols contain `hideUntil` prop', function() {
+    const wrapper = shallow(
+      <ResponsiveTable
+        {...requiredProps()}
+        cols={[
+          { title: 'Column 1', hideUntil: 100 },
+          { title: 'Column 2', hideUntil: 200 }
+        ]}
+      />
+    )
+    expect(wrapper.find('style').length).toEqual(1)
+  })
+})

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/ResponsiveTableDataCell.module.scss
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/ResponsiveTableDataCell.module.scss
@@ -1,0 +1,4 @@
+.ResponsiveTableDataCell {
+  composes: ResponsiveTableCommonCellStyles from '../../ResponsiveTable.module.scss';
+  border-bottom: 1px solid lightgrey;
+}

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/ResponsiveTableDataCell.test.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/ResponsiveTableDataCell.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import validatePropTypes from 'validate-prop-types'
+import { shallow } from 'enzyme'
+import ResponsiveTableDataCell from '.'
+
+const requiredProps = () => ({})
+
+describe('Component: ResponsiveTableDataCell', function() {
+  // test('should return errors if required props missing', function() {
+  //   // eslint-disable-next-line react/forbid-foreign-prop-types
+  //   const actual = validatePropTypes(ResponsiveTableDataCell.propTypes, {})
+  //   const expected = {
+  //     children:
+  //       'The prop `children` is marked as required in `Component`, but its value is `undefined`.'
+  //   }
+  //   expect(actual).toEqual(expected)
+  // })
+
+  test('shouldn’t error if valid default props passed', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(
+      ResponsiveTableDataCell.propTypes,
+      requiredProps()
+    )
+    const expected = undefined
+    expect(actual).toEqual(expected)
+  })
+
+  test('should output the expected markup with default props', function() {
+    const wrapper = shallow(<ResponsiveTableDataCell {...requiredProps()} />)
+    expect(wrapper.prop('className')).toEqual('ResponsiveTableDataCell')
+    expect(wrapper.text()).toEqual('')
+  })
+
+  test('should output additional content when `children` prop passed', function() {
+    const wrapper = shallow(
+      <ResponsiveTableDataCell {...requiredProps()}>
+        Default Content
+      </ResponsiveTableDataCell>
+    )
+    expect(wrapper.text()).toEqual('Default Content')
+  })
+
+  test('should output additional className when `foo` prop passed', function() {
+    const wrapper = shallow(
+      <ResponsiveTableDataCell {...requiredProps()} hideUntil={200} />
+    )
+    expect(wrapper.prop('className')).toEqual(
+      'ResponsiveTableDataCell hideUntil-200'
+    )
+  })
+})

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import classNames from 'classnames'
-import { node } from 'prop-types'
+import { node, number } from 'prop-types'
 
 import styles from './ResponsiveTableDataCell.module.scss'
 
@@ -22,7 +22,8 @@ class ResponsiveTableDataCell extends PureComponent {
 }
 
 ResponsiveTableDataCell.propTypes = {
-  children: node
+  children: node,
+  hideUntil: number
 }
 
 export default ResponsiveTableDataCell

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableDataCell/index.jsx
@@ -1,0 +1,28 @@
+import React, { PureComponent } from 'react'
+import classNames from 'classnames'
+import { node } from 'prop-types'
+
+import styles from './ResponsiveTableDataCell.module.scss'
+
+class ResponsiveTableDataCell extends PureComponent {
+  render() {
+    const { children, hideUntil } = this.props
+
+    return (
+      <td
+        className={classNames(
+          styles.ResponsiveTableDataCell,
+          hideUntil && `hideUntil-${hideUntil}`
+        )}
+      >
+        {children}
+      </td>
+    )
+  }
+}
+
+ResponsiveTableDataCell.propTypes = {
+  children: node
+}
+
+export default ResponsiveTableDataCell

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/ResponsiveTableHeaderCell.module.scss
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/ResponsiveTableHeaderCell.module.scss
@@ -1,0 +1,9 @@
+.ResponsiveTableHeaderCell {
+  composes: ResponsiveTableCommonCellStyles from '../../ResponsiveTable.module.scss';
+  text-transform: uppercase;
+  border-bottom: 1px solid;
+
+  abbr {
+    border-bottom: 0;
+  }
+}

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/ResponsiveTableHeaderCell.test.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/ResponsiveTableHeaderCell.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import validatePropTypes from 'validate-prop-types'
+import { shallow } from 'enzyme'
+import ResponsiveTableHeaderCell from '.'
+
+import VisuallyHidden from '../../../VisuallyHidden'
+
+const requiredProps = () => ({ title: 'Default title' })
+
+describe('Component: ResponsiveTableHeaderCell', function() {
+  test('should return errors if required props missing', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(ResponsiveTableHeaderCell.propTypes, {})
+    const expected = {
+      title:
+        'The prop `title` is marked as required in `Component`, but its value is `undefined`.'
+    }
+    expect(actual).toEqual(expected)
+  })
+
+  test('shouldn’t error if valid default props passed', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(
+      ResponsiveTableHeaderCell.propTypes,
+      requiredProps()
+    )
+    const expected = undefined
+    expect(actual).toEqual(expected)
+  })
+
+  test('should output the expected markup with default props', function() {
+    const wrapper = shallow(<ResponsiveTableHeaderCell {...requiredProps()} />)
+    expect(wrapper.prop('className')).toEqual('ResponsiveTableHeaderCell')
+    expect(wrapper.text()).toEqual('Default title')
+  })
+
+  test('should output additional className when `foo` prop passed', function() {
+    const wrapper = shallow(
+      <ResponsiveTableHeaderCell {...requiredProps()} hideUntil={200} />
+    )
+    expect(wrapper.prop('className')).toEqual(
+      'ResponsiveTableHeaderCell hideUntil-200'
+    )
+  })
+
+  test('should output title as accessible abbreviation if `abbr` prop set', function() {
+    const wrapper = shallow(
+      <ResponsiveTableHeaderCell {...requiredProps()} abbr="DT" />
+    )
+    expect(wrapper.childAt(0).type()).toEqual('abbr')
+    expect(wrapper.childAt(0).text()).toEqual('DT')
+    expect(wrapper.childAt(0).prop('title')).toEqual('Default title')
+  })
+
+  test('should output visually-hidden title if `hideTitle` prop set', function() {
+    const wrapper = shallow(
+      <ResponsiveTableHeaderCell {...requiredProps()} hideTitle />
+    )
+    expect(wrapper.childAt(0).type()).toEqual(VisuallyHidden)
+    expect(
+      wrapper
+        .childAt(0)
+        .dive()
+        .text()
+    ).toEqual('Default title')
+  })
+
+  test('should output visually-hidden title with `abbr` if `hideTitle` props set', function() {
+    const wrapper = shallow(
+      <ResponsiveTableHeaderCell {...requiredProps()} abbr="DT" hideTitle />
+    )
+    expect(wrapper.childAt(0).type()).toEqual(VisuallyHidden)
+    expect(
+      wrapper
+        .childAt(0)
+        .dive()
+        .text()
+    ).toEqual('Default title (DT)')
+  })
+})

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableHeaderCell/index.jsx
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react'
+import classNames from 'classnames'
+import { bool, number, string } from 'prop-types'
+
+import styles from './ResponsiveTableHeaderCell.module.scss'
+
+import VisuallyHidden from '../../../VisuallyHidden'
+
+class ResponsiveTableHeaderCell extends PureComponent {
+  render() {
+    const { abbr, hideTitle, hideUntil, title } = this.props
+
+    return (
+      <th
+        scope="col"
+        className={classNames(
+          styles.ResponsiveTableHeaderCell,
+          hideUntil && `hideUntil-${hideUntil}`
+        )}
+      >
+        {/* TODO: Better logic here */}
+        {hideTitle && (
+          <VisuallyHidden>
+            {title}
+            {abbr && ` (${abbr})`}
+          </VisuallyHidden>
+        )}
+        {!hideTitle && abbr && <abbr title={title}>{abbr}</abbr>}
+        {!hideTitle && !abbr && title}
+      </th>
+    )
+  }
+}
+
+ResponsiveTableHeaderCell.propTypes = {
+  abbr: string,
+  hideTitle: bool,
+  hideUntil: number,
+  title: string.isRequired
+}
+
+export default ResponsiveTableHeaderCell

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/ResponsiveTableRow.module.scss
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/ResponsiveTableRow.module.scss
@@ -1,0 +1,13 @@
+.ResponsiveTableRow {
+  margin-left: 20px;
+
+  &.highlighted {
+    background-color: lightblue;
+  }
+
+  &.separatorBelow {
+    > * {
+      border-bottom: 1px dashed;
+    }
+  }
+}

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/ResponsiveTableRow.test.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/ResponsiveTableRow.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import validatePropTypes from 'validate-prop-types'
+import { shallow } from 'enzyme'
+import ResponsiveTableRow from '.'
+
+const requiredProps = () => ({ children: <td>Default content</td> })
+
+describe('Component: ResponsiveTableRow', function() {
+  test('should return errors if required props missing', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(ResponsiveTableRow.propTypes, {})
+    const expected = {
+      children:
+        'The prop `children` is marked as required in `Component`, but its value is `undefined`.'
+    }
+    expect(actual).toEqual(expected)
+  })
+
+  test('shouldn’t error if valid default props passed', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(
+      ResponsiveTableRow.propTypes,
+      requiredProps()
+    )
+    const expected = undefined
+    expect(actual).toEqual(expected)
+  })
+
+  test('should output the expected markup with default props', function() {
+    const wrapper = shallow(<ResponsiveTableRow {...requiredProps()} />)
+    expect(wrapper.prop('className')).toEqual('ResponsiveTableRow')
+    expect(wrapper.prop('children')).toEqual(<td>Default content</td>)
+  })
+
+  test('should output additional className when `highlighted` prop passed', function() {
+    const wrapper = shallow(
+      <ResponsiveTableRow {...requiredProps()} highlighted />
+    )
+    expect(wrapper.prop('className')).toEqual('ResponsiveTableRow highlighted')
+  })
+
+  test('should output additional className when `separatorBelow` prop passed', function() {
+    const wrapper = shallow(
+      <ResponsiveTableRow {...requiredProps()} separatorBelow />
+    )
+    expect(wrapper.prop('className')).toEqual(
+      'ResponsiveTableRow separatorBelow'
+    )
+  })
+})

--- a/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/component/ResponsiveTableRow/index.jsx
@@ -1,0 +1,31 @@
+import React, { PureComponent } from 'react'
+import classNames from 'classnames'
+import { bool, node } from 'prop-types'
+
+import styles from './ResponsiveTableRow.module.scss'
+
+class ResponsiveTableRow extends PureComponent {
+  render() {
+    const { children, highlighted, separatorBelow } = this.props
+
+    return (
+      <tr
+        className={classNames(
+          styles.ResponsiveTableRow,
+          highlighted && styles.highlighted,
+          separatorBelow && styles.separatorBelow
+        )}
+      >
+        {children}
+      </tr>
+    )
+  }
+}
+
+ResponsiveTableRow.propTypes = {
+  children: node.isRequired,
+  highlighted: bool,
+  separatorBelow: bool
+}
+
+export default ResponsiveTableRow

--- a/src/component/Primitive/ResponsiveTable/fixture/football.jsx
+++ b/src/component/Primitive/ResponsiveTable/fixture/football.jsx
@@ -1,0 +1,113 @@
+import React from 'react'
+
+import ShrinkWrap from '../../ShrinkWrap'
+
+const cols = [
+  { title: 'Position', abbr: 'Pos', hideTitle: true },
+  { title: 'Team' },
+  { title: 'Played', hideUntil: 420 },
+  { title: 'Won', hideUntil: 600 },
+  { title: 'Drawn', hideUntil: 600 },
+  { title: 'Lost', hideUntil: 600 },
+  { title: 'Goals for', abbr: 'For', hideUntil: 800 },
+  { title: 'Gaols against', abbr: 'Against', hideUntil: 800 },
+  { title: 'Goal difference', abbr: 'GD', hideUntil: 880 },
+  { title: 'Points' },
+  { title: 'Form', hideUntil: 1000 }
+]
+
+const teams = [
+  {
+    club: 'Manchester City',
+    played: 27,
+    won: 21,
+    drawn: 2,
+    lost: 4,
+    for: 74,
+    against: 20,
+    goalDifference: 54,
+    points: 66,
+    form: 'WLWWW'
+  },
+  {
+    club: 'Liverpool',
+    played: 26,
+    won: 20,
+    drawn: 5,
+    lost: 1,
+    for: 59,
+    against: 15,
+    goalDifference: 44,
+    points: 65,
+    form: 'WWDDW'
+  },
+  {
+    club: 'Tottenham Hospur',
+    played: 26,
+    won: 20,
+    drawn: 0,
+    lost: 6,
+    for: 54,
+    against: 25,
+    goalDifference: 29,
+    points: 60,
+    form: 'LWWWW'
+  },
+  {
+    club: 'Manchester United',
+    played: 26,
+    won: 15,
+    drawn: 6,
+    lost: 5,
+    for: 52,
+    against: 35,
+    goalDifference: 17,
+    points: 51,
+    form: 'WWDWW'
+  },
+  {
+    club: 'Arsenal',
+    played: 26,
+    won: 15,
+    drawn: 5,
+    lost: 6,
+    for: 53,
+    against: 37,
+    goalDifference: 16,
+    points: 50,
+    form: 'LLWLW'
+  },
+  {
+    club: 'Chelsea',
+    played: 26,
+    won: 15,
+    drawn: 5,
+    lost: 6,
+    for: 45,
+    against: 29,
+    goalDifference: 16,
+    points: 50,
+    form: 'WLLWL'
+  }
+]
+
+const rows = teams.map((team, i) => {
+  const position = i + 1
+  const separatorBelow = [4, 5, 7].includes(position)
+  const data = [
+    position,
+    team.club,
+    team.played,
+    team.won,
+    team.drawn,
+    team.lost,
+    team.for,
+    team.against,
+    team.goalDifference,
+    team.points,
+    team.form
+  ]
+  return { data, separatorBelow }
+})
+
+export { cols, rows }

--- a/src/component/Primitive/ResponsiveTable/fixture/olympics.jsx
+++ b/src/component/Primitive/ResponsiveTable/fixture/olympics.jsx
@@ -1,0 +1,71 @@
+import React from 'react'
+
+import ShrinkWrap from '../../ShrinkWrap'
+
+const cols = [
+  { title: 'Rank' },
+  { title: 'National Olympic Committee', abbr: 'NOC' },
+  { title: 'Gold' },
+  { title: 'Silver' },
+  { title: 'Bronze' },
+  { title: 'Total' }
+]
+
+const highlightedTeamId = '1000'
+
+const data = [
+  {
+    rank: 1,
+    noc: 'United States',
+    nocCode: 'USA',
+    flag: '🇺🇸',
+    gold: 46,
+    silver: 28,
+    bronze: 29,
+    total: 103
+  },
+  {
+    rank: 2,
+    noc: 'China',
+    nocCode: 'CHN',
+    flag: '🇨🇳',
+    gold: 38,
+    silver: 31,
+    bronze: 22,
+    total: 91
+  },
+  {
+    rank: 3,
+    noc: 'Great Britain',
+    nocCode: 'GBR',
+    flag: '🇬🇧',
+    gold: 29,
+    silver: 17,
+    bronze: 19,
+    total: 65
+  }
+]
+
+const rows = data.map(item => {
+  const highlighted = item.itemId === highlightedTeamId
+  const data = [
+    item.rank,
+    <ShrinkWrap>
+      <ShrinkWrap.Item>
+        <span role="img" aria-label={`Flag of ${item.noc}`}>
+          {item.flag}
+        </span>
+      </ShrinkWrap.Item>
+      <ShrinkWrap.Item>
+        {item.noc} ({item.nocCode})
+      </ShrinkWrap.Item>
+    </ShrinkWrap>,
+    item.gold,
+    item.silver,
+    item.bronze,
+    item.total
+  ]
+  return { data, highlighted }
+})
+
+export { cols, rows }

--- a/src/component/Primitive/ResponsiveTable/fixture/rugby.jsx
+++ b/src/component/Primitive/ResponsiveTable/fixture/rugby.jsx
@@ -1,0 +1,110 @@
+import React from 'react'
+
+import ShrinkWrap from '../../ShrinkWrap'
+
+const cols = [
+  { title: 'Position', abbr: 'Pos' },
+  { title: 'Team', abbr: 'Team' },
+  { title: 'Played', abbr: 'Pl' },
+  { title: 'Won', abbr: 'W', hideUntil: 350 },
+  { title: 'Drawn', abbr: 'D', hideUntil: 350 },
+  { title: 'Lost', abbr: 'L', hideUntil: 350 },
+  { title: 'Points for', abbr: 'PF', hideUntil: 650 },
+  { title: 'Points against', abbr: 'PA', hideUntil: 650 },
+  { title: 'Points difference', abbr: 'Diff', hideUntil: 650 },
+  { title: 'Tries for', abbr: 'TF', hideUntil: 730 },
+  { title: 'Tries against', abbr: 'TA', hideUntil: 730 },
+  { title: 'Tries bonus points', abbr: 'TBP', hideUntil: 860 },
+  { title: 'Losing bonus points', abbr: 'LBP', hideUntil: 860 },
+  { title: 'Total bonus points', abbr: 'BP', hideUntil: 860 },
+  { title: 'League Points', abbr: 'Pts' }
+]
+const homeTeamId = '1000'
+
+const teams = [
+  {
+    displayName: 'Northampton Saints',
+    teamId: '1400',
+    position: '1',
+    played: '22',
+    won: '16',
+    drawn: '1',
+    lost: '5',
+    pointsFor: '621',
+    pointsAgainst: '400',
+    pointsDiff: '221',
+    triesFor: '75',
+    triesAgainst: '41',
+    triesBonusPoints: '8',
+    losingBonusPoints: '2',
+    totalBonusPoints: '10',
+    points: '76'
+  },
+  {
+    displayName: 'Bath Rugby',
+    teamId: '1000',
+    position: '2',
+    played: '22',
+    won: '16',
+    drawn: '0',
+    lost: '6',
+    pointsFor: '625',
+    pointsAgainst: '414',
+    pointsDiff: '211',
+    triesFor: '72',
+    triesAgainst: '43',
+    triesBonusPoints: '9',
+    losingBonusPoints: '2',
+    totalBonusPoints: '11',
+    points: '75'
+  },
+  {
+    displayName: 'Leicester Tigers',
+    teamId: '1250',
+    position: '3',
+    played: '22',
+    won: '15',
+    drawn: '1',
+    lost: '6',
+    pointsFor: '453',
+    pointsAgainst: '421',
+    pointsDiff: '32',
+    triesFor: '37',
+    triesAgainst: '39',
+    triesBonusPoints: '4',
+    losingBonusPoints: '2',
+    totalBonusPoints: '6',
+    points: '68'
+  }
+]
+
+const rows = teams.map(team => {
+  const highlighted = team.teamId === homeTeamId
+  const data = [
+    team.position,
+    <ShrinkWrap>
+      <ShrinkWrap.Item>
+        <span role="img" aria-label="Rocket">
+          🚀
+        </span>
+      </ShrinkWrap.Item>
+      <ShrinkWrap.Item>{team.displayName}</ShrinkWrap.Item>
+    </ShrinkWrap>,
+    team.played,
+    team.won,
+    team.drawn,
+    team.lost,
+    team.pointsFor,
+    team.pointsAgainst,
+    team.pointsDiff,
+    team.triesFor,
+    team.triesAgainst,
+    team.triesBonusPoints,
+    team.losingBonusPoints,
+    team.totalBonusPoints,
+    team.points
+  ]
+  return { data, highlighted }
+})
+
+export { cols, rows }

--- a/src/component/Primitive/ResponsiveTable/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/index.jsx
@@ -1,0 +1,73 @@
+//
+// TO CONSIDER:
+// Widths of `hideUntil` are relative to the viewport - not the width of the table…
+//
+// Similar setup to `hideUntil` for abbr/title switchover. Could use same
+// show/hide classes as hideUntil to avoid duplication if matching values.
+//
+
+import React, { PureComponent } from 'react'
+import { array } from 'prop-types'
+
+import styles from './ResponsiveTable.module.scss'
+
+import widthStylesFormatter from './lib/width-styles-formatter'
+
+import ResponsiveTableDataCell from './component/ResponsiveTableDataCell'
+import ResponsiveTableHeaderCell from './component/ResponsiveTableHeaderCell'
+import ResponsiveTableRow from './component/ResponsiveTableRow'
+
+class ResponsiveTable extends PureComponent {
+  render() {
+    const { cols, rows } = this.props
+
+    const hiddenWidths = [...new Set(cols.map(col => col.hideUntil))].filter(
+      col => col !== undefined
+    )
+
+    return (
+      <div className={styles.ResponsiveTable}>
+        {hiddenWidths.length > 0 && (
+          <style
+            dangerouslySetInnerHTML={{
+              __html: widthStylesFormatter(hiddenWidths)
+            }}
+          />
+        )}
+        <table className={styles.ResponsiveTableTable}>
+          <thead>
+            <tr>
+              {cols.map((col, i) => (
+                <ResponsiveTableHeaderCell
+                  key={`ResponsiveTableHeading${i}`}
+                  {...col}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <ResponsiveTableRow key={`ResponsiveTableRow${i}`} {...row}>
+                {row.data.map((dataCell, j) => (
+                  <ResponsiveTableDataCell
+                    key={`ResponsiveTableDataCell${j}`}
+                    hideUntil={cols[j].hideUntil}
+                  >
+                    {dataCell}
+                  </ResponsiveTableDataCell>
+                ))}
+              </ResponsiveTableRow>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+ResponsiveTable.propTypes = {
+  cols: array.isRequired, //TODO: define shape
+  rows: array.isRequired //TODO: define shape
+}
+
+export default ResponsiveTable

--- a/src/component/Primitive/ResponsiveTable/index.jsx
+++ b/src/component/Primitive/ResponsiveTable/index.jsx
@@ -66,8 +66,8 @@ class ResponsiveTable extends PureComponent {
 }
 
 ResponsiveTable.propTypes = {
-  cols: array.isRequired, //TODO: define shape
-  rows: array.isRequired //TODO: define shape
+  cols: array.isRequired, // TODO: define shape
+  rows: array.isRequired // TODO: define shape
 }
 
 export default ResponsiveTable

--- a/src/component/Primitive/ResponsiveTable/lib/width-styles-formatter.js
+++ b/src/component/Primitive/ResponsiveTable/lib/width-styles-formatter.js
@@ -1,0 +1,15 @@
+const widthStylesFormatter = widths => {
+  if (!Array.isArray(widths) || widths.length === 0) return
+
+  return widths
+    .map(width => {
+      if (typeof width !== 'number') return null
+
+      return `@media all and (max-width: ${width -
+        1}px) { .hideUntil-${width} { display: none; } }`
+    })
+    .join(' ')
+    .trim()
+}
+
+export default widthStylesFormatter

--- a/src/component/Primitive/ResponsiveTable/lib/width-styles-formatter.test.js
+++ b/src/component/Primitive/ResponsiveTable/lib/width-styles-formatter.test.js
@@ -1,0 +1,29 @@
+import widthStylesFormatter from './width-styles-formatter'
+
+describe('widthStylesFormatter', function() {
+  test('should return single width in expected formats', function() {
+    expect(widthStylesFormatter([100])).toEqual(
+      `@media all and (max-width: 99px) { .hideUntil-100 { display: none; } }`
+    )
+  })
+
+  test('should return multiple widths in expected formats', function() {
+    expect(widthStylesFormatter([100, 200])).toEqual(
+      `@media all and (max-width: 99px) { .hideUntil-100 { display: none; } } @media all and (max-width: 199px) { .hideUntil-200 { display: none; } }`
+    )
+  })
+
+  test('should return nothing when no widths passed', function() {
+    expect(widthStylesFormatter([])).toEqual(undefined)
+  })
+
+  test('should return nothing when no widths passed', function() {
+    expect(widthStylesFormatter()).toEqual(undefined)
+  })
+
+  test('should skip non-numeric values', function() {
+    expect(widthStylesFormatter([100, 'b', () => {}])).toEqual(
+      `@media all and (max-width: 99px) { .hideUntil-100 { display: none; } }`
+    )
+  })
+})


### PR DESCRIPTION
_This is something I'm putting together for another project, but made sense to build here and port across, so I can ask for opinions too. I’d rather not be adding components of this complexity this soon._

About the component (so far):
- An HTML table which accepts arrays of columns (for headings) and rows.
- Columns can specify a title, and optionally an abbreviation (to then use `<abbr>`).
- Columns can set a `hiddenUntil` width (in px) to tweak content shown per-device size
- Rows can have a `hightlighted` style (useful for preferred team etc)
- Rows can have trailing separator styles (to denote relegation/playoff cutoffs etc)
- All content rendered on all devices, then revealed/hidden based on device width
  - Pros: SSR friendly, no client-side JS or re-renders required
  - Cons: too much content for mobile-only devices

TODO:
- Storybook info, update examples

TBC: 
- [ ] Better name? - there are lots of different methods for making tables responsive, so I'd rather not squat the name just because this was the first. We'll likely need at least a version that side-scrolls to avoid hiding content. It might be that this component could do both but I haven't had time to do the work yet
- [ ] `hiddenUntil` is relative to the viewport, not the table width *wishes for container queries*
- [ ] Process to prep cols/rows pretty involved, and tied in col `hiddenUntil` widths limit reuse in different locations on page would be troublesome if table displayed at different widths
- [ ] More JS-reliant measurement-style show/hiding of content based on table width
- [ ] Vertical headers option?
- [ ] Sticky headers option?
