### PR TITLE
feat(offset-anchor): Adds OffsetAnchor Component

### DIFF
--- a/src/component/Primitive/OffsetAnchor/OffsetAnchor.module.scss
+++ b/src/component/Primitive/OffsetAnchor/OffsetAnchor.module.scss
@@ -1,0 +1,7 @@
+@import '../../../scss/function/spacing';
+
+.OffsetAnchor {
+  visibility: hidden;
+  height: spacing(5);
+  margin-top: spacing(-5);
+}

--- a/src/component/Primitive/OffsetAnchor/OffsetAnchor.stories.jsx
+++ b/src/component/Primitive/OffsetAnchor/OffsetAnchor.stories.jsx
@@ -1,0 +1,27 @@
+import React, { Fragment } from 'react'
+import { storiesOf } from '@storybook/react'
+
+import OffsetAnchor from '.'
+import SmartLink from '../SmartLink'
+
+const stories = storiesOf('Utility/OffsetAnchor', module)
+
+stories.add('Info', () => <OffsetAnchor name="foo" />, {
+  info: {
+    inline: true,
+    text: `
+      OffsetAnchor component allows creation of a fixed point on a page which is visually offset from the top of the viewport. A use case for this would be a long FAQs or Terms & Conditions page, on a site which has a sticky navigation.
+    `
+  }
+})
+
+stories.add('Default state', () => (
+  <Fragment>
+    <SmartLink href='#foo'>Link to Anchor</SmartLink>
+    <div style={{'height': '1000px'}} />
+    <OffsetAnchor identifier="foo" />
+    <div style={{'height': '1000px'}}>
+      Content associated with anchor
+    </div>
+  </Fragment>
+))

--- a/src/component/Primitive/OffsetAnchor/OffsetAnchor.test.jsx
+++ b/src/component/Primitive/OffsetAnchor/OffsetAnchor.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import validatePropTypes from 'validate-prop-types'
+import { shallow } from 'enzyme'
+import OffsetAnchor from '.'
+
+const requiredProps = () => ({ identifier: 'foo' })
+
+describe('Component: OffsetAnchor', function() {
+  test('should return errors if required props missing', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(OffsetAnchor.propTypes, {})
+    const expected = {
+      identifier:
+        'The prop `identifier` is marked as required in `Component`, but its value is `undefined`.'
+    }
+    expect(actual).toEqual(expected)
+  })
+
+  test('shouldn’t error if valid default props passed', function() {
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const actual = validatePropTypes(OffsetAnchor.propTypes, requiredProps())
+    const expected = undefined
+    expect(actual).toEqual(expected)
+  })
+
+  test('should output the expected markup with default props', function() {
+    const wrapper = shallow(<OffsetAnchor {...requiredProps()} />)
+    expect(wrapper.prop('className')).toEqual('OffsetAnchor')
+    expect(wrapper.prop('id')).toEqual('foo')
+  })
+})

--- a/src/component/Primitive/OffsetAnchor/index.jsx
+++ b/src/component/Primitive/OffsetAnchor/index.jsx
@@ -1,0 +1,21 @@
+import React, { PureComponent } from 'react'
+import { string } from 'prop-types'
+
+import styles from './OffsetAnchor.module.scss'
+
+class OffsetAnchor extends PureComponent {
+  
+  render() {
+    const { identifier } = this.props
+    return <div
+      className={styles.OffsetAnchor}
+      id={identifier}
+    />
+  }
+}
+
+OffsetAnchor.propTypes = {
+  identifier: string.isRequired
+}
+
+export default OffsetAnchor


### PR DESCRIPTION
OffsetAnchor allows a linkable fixed point in a page that isn't visible to the user but is navigable to. Useful for long FAQs or Terms and Conditions pages on sites that have a sticky navigation, for examples.

Currently the offset value is fixed to 50px, but this would be dependent on the size of the sticky element.